### PR TITLE
docs(submit-work): simplify --media-key vs --proof-url section

### DIFF
--- a/skills/submit-work/SKILL.md
+++ b/skills/submit-work/SKILL.md
@@ -90,16 +90,6 @@ At least one of `--text`, `--media-key`, or `--proof-url` must be provided. In p
 | **You uploaded a file** (image, video, document) | `--media-key` | The `key` field from `upload` command |
 | **External link** (GitHub PR, deployed site, IPFS) | `--proof-url` | Full URL starting with `https://` |
 
-**Decision Rule**:
-- File on your local machine? → Run `upload` first, then use `--media-key "proofs/..."`
-- Link already on the internet? → Use `--proof-url "https://..."` directly
-
-**Common Mistakes**:
-- `--proof-url "proofs/2026-03-01/abc.mp4"` — WRONG! This is a key, not a URL
-- `--media-key "https://storage.openant.ai/..."` — WRONG! This is a URL, not a key
-- `--media-key "proofs/2026-03-01/abc.mp4"` — Correct!
-- `--proof-url "https://github.com/org/repo/pull/42"` — Correct!
-
 ## Examples
 
 ### Upload file then submit (recommended)


### PR DESCRIPTION
## Description

Simplify the `--media-key` vs `--proof-url` documentation by keeping only the comparison table.

## Skill Changes

- [x] Modified skill: `skills/submit-work/SKILL.md`

## Changes

- Remove "Decision Rule" section
- Remove "Common Mistakes" section  
- Keep comparison table for quick reference

## Checklist

- [x] SKILL.md has valid YAML frontmatter
- [x] All CLI examples use `--json` flag