### PR TITLE
feat: align skills with CLI unified chain identifier (evm)

### DIFF
--- a/skills/check-wallet/SKILL.md
+++ b/skills/check-wallet/SKILL.md
@@ -34,7 +34,7 @@ Returns all wallet addresses (Solana + EVM) managed by Turnkey:
   "data": {
     "addresses": [
       { "chain": "Solana", "address": "7xK...abc", "addressFormat": "ADDRESS_FORMAT_SOLANA" },
-      { "chain": "EVM (Base)", "address": "0xAb...12", "addressFormat": "ADDRESS_FORMAT_ETHEREUM" }
+      { "chain": "EVM (ETH)", "address": "0xAb...12", "addressFormat": "ADDRESS_FORMAT_ETHEREUM" }
     ]
   }
 }
@@ -46,7 +46,7 @@ Returns all wallet addresses (Solana + EVM) managed by Turnkey:
 npx @openant-ai/cli@latest wallet balance --json
 ```
 
-Returns SOL balance, SPL token balances (USDC auto-detected), EVM native balance, and Base USDC balance:
+Returns SOL balance, SPL token balances (USDC auto-detected), EVM native balance, and EVM USDC balance:
 
 ```json
 {

--- a/skills/create-task/SKILL.md
+++ b/skills/create-task/SKILL.md
@@ -46,7 +46,7 @@ npx @openant-ai/cli@latest tasks create [options] --json
 
 | Option | Description |
 |--------|-------------|
-| `--token <symbol>` | Token format: `USDC` (Solana, default), `SOL`, `ETH` (Base), `ETH:USDC` or `BASE:USDC` (Base USDC), `SOL:USDC`, or Solana mint address |
+| `--token <symbol>` | Token format: `USDC` (Solana, default), `SOL`, `ETH` (EVM), `EVM:USDC` or `ETH:USDC` (EVM USDC), `SOL:USDC`, or Solana mint address |
 | `--tags <tags>` | Comma-separated tags (e.g. `solana,rust,security-audit`) |
 | `--deadline <iso8601>` | ISO 8601 deadline (e.g. `2026-03-15T00:00:00Z`) |
 | `--mode <mode>` | Distribution: `OPEN` (default), `APPLICATION`, `DISPATCH` |
@@ -67,9 +67,9 @@ npx @openant-ai/cli@latest tasks create \
   --tags solana,rust,security-audit \
   --deadline 2026-03-15T00:00:00Z \
   --mode APPLICATION --verification CREATOR --json
-# -> Creates task, builds escrow tx, signs via Turnkey, sends to Solana or Base
+# -> Creates task, builds escrow tx, signs via Turnkey, sends to Solana or EVM
 # -> Solana: { "success": true, "data": { "id": "task_abc", "txId": "5xYz...", "escrowPDA": "...", "vaultPDA": "..." } }
-# -> Base (ETH): { "success": true, "data": { "id": "task_abc", "txId": "0xabc..." } }
+# -> EVM: { "success": true, "data": { "id": "task_abc", "txId": "0xabc..." } }
 ```
 
 ### Create a DRAFT first, fund later
@@ -86,15 +86,15 @@ npx @openant-ai/cli@latest tasks create \
 # Fund it later (sends on-chain tx)
 npx @openant-ai/cli@latest tasks fund task_abc --json
 # -> Solana: { "success": true, "data": { "taskId": "task_abc", "txSignature": "5xYz...", "escrowPDA": "..." } }
-# -> Base (ETH): { "success": true, "data": { "taskId": "task_abc", "txHash": "0xabc..." } }
+# -> EVM: { "success": true, "data": { "taskId": "task_abc", "txHash": "0xabc..." } }
 ```
 
-### Create an ETH task on Base (EVM)
+### Create an ETH task on EVM
 
 ```bash
 npx @openant-ai/cli@latest tasks create \
   --title "Smart contract audit" \
-  --description "Audit my ERC-20 contract on Base for security vulnerabilities..." \
+  --description "Audit my ERC-20 contract on EVM for security vulnerabilities..." \
   --reward 0.01 --token ETH \
   --tags evm,base,audit \
   --deadline 2026-03-15T00:00:00Z \
@@ -102,13 +102,13 @@ npx @openant-ai/cli@latest tasks create \
 # -> { "success": true, "data": { "id": "task_abc", "txId": "0xabc..." } }
 ```
 
-### Create a USDC task on Base (EVM)
+### Create a USDC task on EVM
 
 ```bash
 npx @openant-ai/cli@latest tasks create \
   --title "Frontend development" \
   --description "Build a React dashboard with TypeScript..." \
-  --reward 100 --token ETH:USDC \
+  --reward 100 --token EVM:USDC \
   --tags frontend,react,typescript \
   --deadline 2026-03-15T00:00:00Z \
   --mode OPEN --json
@@ -140,9 +140,9 @@ npx @openant-ai/cli@latest tasks create \
 
 ## NEVER
 
-- **NEVER fund a task without checking wallet balance first** — run `wallet balance --json` before creating a funded task. Check the correct chain: Solana balance for `USDC`, `SOL`, `SOL:USDC` tasks; EVM (Base) balance for `ETH`, `ETH:USDC`, `BASE:USDC` tasks. An insufficient balance causes the on-chain transaction to fail, wasting gas fees, and leaves the task in a broken DRAFT state.
+- **NEVER fund a task without checking wallet balance first** — run `wallet balance --json` before creating a funded task. Check the correct chain: Solana balance for `USDC`, `SOL`, `SOL:USDC` tasks; EVM balance for `ETH`, `EVM:USDC`, `ETH:USDC` tasks. An insufficient balance causes the on-chain transaction to fail, wasting gas fees, and leaves the task in a broken DRAFT state.
 - **NEVER create a funded task with a vague or incomplete description** — once the escrow transaction is sent, the reward amount cannot be changed. If the description doesn't match what the worker delivers, disputes are hard to resolve.
-- **NEVER set a deadline in the past or less than 24 hours away** — the on-chain escrow contract (Solana or Base) uses the deadline as the settlement time. Too short a deadline leaves no time for the worker to do the job.
+- **NEVER set a deadline in the past or less than 24 hours away** — the on-chain escrow contract (Solana or EVM) uses the deadline as the settlement time. Too short a deadline leaves no time for the worker to do the job.
 - **NEVER use APPLICATION mode for urgent tasks** — creators must manually review and accept each application, which takes time. Use OPEN mode if you need someone to start immediately.
 - **NEVER omit `--verification CREATOR` unless you understand the alternatives** — `THIRD_PARTY` verification routes funds through a third-party verifier. When in doubt, stick with `CREATOR` so you remain in control of the payout decision.
 

--- a/skills/send-token/SKILL.md
+++ b/skills/send-token/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: send-token
-description: Transfer tokens on Solana or Base (EVM). Use when the user wants to send, transfer, or pay tokens. Supports native coins (SOL, ETH) and tokens (USDC) by name, plus arbitrary tokens by mint/contract address. Covers "send SOL", "transfer USDC", "send tokens", "pay someone", "send ETH on Base", "transfer to address".
+description: Transfer tokens on Solana or EVM (ETH chain). Use when the user wants to send, transfer, or pay tokens. Supports native coins (SOL, ETH) and tokens (USDC) by name, plus arbitrary tokens by mint/contract address. Covers "send SOL", "transfer USDC", "send tokens", "pay someone", "send ETH on EVM", "transfer to address".
 user-invocable: true
 disable-model-invocation: false
 allowed-tools: ["Bash(npx @openant-ai/cli@latest wallet send *)", "Bash(npx @openant-ai/cli@latest wallet balance*)", "Bash(npx @openant-ai/cli@latest wallet addr*)", "Bash(npx @openant-ai/cli@latest status*)"]
@@ -8,7 +8,7 @@ allowed-tools: ["Bash(npx @openant-ai/cli@latest wallet send *)", "Bash(npx @ope
 
 # Sending Tokens on OpenAnt
 
-Use the `npx @openant-ai/cli@latest` CLI to transfer tokens on Solana or Base (EVM). Supports native coins (SOL, ETH), named tokens (USDC), and arbitrary tokens by mint/contract address.
+Use the `npx @openant-ai/cli@latest` CLI to transfer tokens on Solana or EVM. Supports native coins (SOL, ETH), named tokens (USDC), and arbitrary tokens by mint/contract address.
 
 **Always append `--json`** to every command for structured, parseable output.
 
@@ -31,7 +31,7 @@ npx @openant-ai/cli@latest wallet send <chain> <token> <amount> <to> [--json] [-
 
 | Argument | Description |
 |----------|-------------|
-| `chain` | Target chain: `solana` (or `sol`), `base` (or `eth`, `evm`) |
+| `chain` | Target chain: `solana` (or `sol`), `evm` (or `eth`, `base`) |
 | `token` | Token: `sol`, `eth`, `usdc`, or a mint/contract address |
 | `amount` | Amount in display units (e.g. `10` = 10 USDC, `0.5` = 0.5 SOL) |
 | `to` | Destination address (Solana pubkey or EVM 0x address) |
@@ -48,7 +48,7 @@ npx @openant-ai/cli@latest wallet send <chain> <token> <amount> <to> [--json] [-
 | Chain | Named tokens | Native coin |
 |-------|-------------|-------------|
 | `solana` / `sol` | `usdc`, or any SPL mint address | `sol` |
-| `base` / `eth` / `evm` | `usdc`, or any ERC20 contract address | `eth` |
+| `evm` / `eth` / `base` | `usdc`, or any ERC20 contract address | `eth` |
 
 For arbitrary tokens, pass the mint address (Solana) or contract address (EVM) directly as the `token` argument.
 
@@ -68,18 +68,18 @@ npx @openant-ai/cli@latest wallet send solana usdc 100 7xKabc123... --json
 # -> { "success": true, "data": { "chain": "solana", "txSignature": "3aBc..." } }
 ```
 
-### Send ETH on Base
+### Send ETH on EVM
 
 ```bash
-npx @openant-ai/cli@latest wallet send base eth 0.05 0xAbCdEf... --json
-# -> { "success": true, "data": { "chain": "base", "txHash": "0x1a2b..." } }
+npx @openant-ai/cli@latest wallet send evm eth 0.05 0xAbCdEf... --json
+# -> { "success": true, "data": { "chain": "evm", "txHash": "0x1a2b..." } }
 ```
 
-### Send USDC on Base
+### Send USDC on EVM
 
 ```bash
-npx @openant-ai/cli@latest wallet send base usdc 50 0xAbCdEf... --json
-# -> { "success": true, "data": { "chain": "base", "txHash": "0x9f8e..." } }
+npx @openant-ai/cli@latest wallet send evm usdc 50 0xAbCdEf... --json
+# -> { "success": true, "data": { "chain": "evm", "txHash": "0x9f8e..." } }
 ```
 
 ### Send arbitrary SPL token by mint address
@@ -91,17 +91,17 @@ npx @openant-ai/cli@latest wallet send solana 4zMMC9srt5Ri5X14GAgXhaHii3GnPAEERY
 ### Send arbitrary ERC20 by contract address
 
 ```bash
-npx @openant-ai/cli@latest wallet send base 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 10 0xAbCdEf... --json
+npx @openant-ai/cli@latest wallet send evm 0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913 10 0xAbCdEf... --json
 ```
 
 ## Natural Language Mapping
 
 When the user says something like:
 
-- "帮我 base 上转 10 usdc 给 0xAbc..." → `wallet send base usdc 10 0xAbc... --json`
+- "帮我 base 上转 10 usdc 给 0xAbc..." → `wallet send evm usdc 10 0xAbc... --json`
 - "帮我 solana 上转 1.5 sol 给 7xK..." → `wallet send solana sol 1.5 7xK... --json`
-- "Send 50 USDC to 0xDef... on Base" → `wallet send base usdc 50 0xDef... --json`
-- "Transfer 0.1 ETH to 0x123..." → `wallet send base eth 0.1 0x123... --json`
+- "Send 50 USDC to 0xDef... on Base/EVM" → `wallet send evm usdc 50 0xDef... --json`
+- "Transfer 0.1 ETH to 0x123..." → `wallet send evm eth 0.1 0x123... --json`
 - "帮我 solana 上转 10 <mint_address> 给 <recipient>" → `wallet send solana <mint_address> 10 <recipient> --json`
 
 Extract: chain, token (name or address), amount, and destination address.
@@ -120,8 +120,8 @@ Read-only commands (`status`, `wallet balance`, `wallet addresses`) can be execu
 
 - **NEVER send without the user explicitly confirming the destination address** — blockchain transfers are irreversible. Show the full address and ask the user to verify it before executing.
 - **NEVER send Solana tokens to an EVM address, or vice versa** — the chains are incompatible. Solana addresses are base58 strings (32–44 chars), EVM addresses start with `0x`. If the address format doesn't match the chain, stop and clarify with the user.
-- **NEVER assume the displayed balance accounts for gas** — Solana transactions require a small SOL fee (~0.000005 SOL); Base transactions require ETH for gas. If the user is sending their entire balance, leave a small reserve or the transaction will fail.
-- **NEVER infer the chain from the token alone** — USDC exists on both Solana and Base. Always confirm which chain the user intends before sending.
+- **NEVER assume the displayed balance accounts for gas** — Solana transactions require a small SOL fee (~0.000005 SOL); EVM transactions require ETH for gas. If the user is sending their entire balance, leave a small reserve or the transaction will fail.
+- **NEVER infer the chain from the token alone** — USDC exists on both Solana and EVM. Always confirm which chain the user intends before sending.
 - **NEVER send to an address the user typed casually without double-checking** — if the user typed the address in the middle of a sentence or abbreviated it, ask them to paste the full address again to confirm.
 
 ## Prerequisites
@@ -134,7 +134,7 @@ Read-only commands (`status`, `wallet balance`, `wallet addresses`) can be execu
 
 - "No Turnkey credentials found" — Run `authenticate-openant` skill first
 - "Insufficient balance" / "Attempt to debit" — Wallet lacks funds; check `wallet balance`
-- "Unknown chain" — Only `solana` and `base` are supported
+- "Unknown chain" — Supported: `sol`, `evm`
 - "No EVM wallet found" / "No Solana wallet found" — Re-login to provision wallets
 - "Cannot read decimals for mint" — Invalid or non-existent token mint address
 - Transaction simulation failed — Check balance and recipient address validity


### PR DESCRIPTION
## Description

Align skill docs with CLI refactor that unified chain identifier from `base` to `evm`.

## Skill Changes

- [x] Modified skill: `skills/send-token/SKILL.md`
- [x] Modified skill: `skills/create-task/SKILL.md`
- [x] Modified skill: `skills/check-wallet/SKILL.md`
- [ ] Updated README skill table

## Changes

- Use `evm` as primary chain identifier (replaces `base`)
- Update JSON output examples: `chain: "evm"`
- Update token format: `EVM:USDC` for EVM USDC tasks
- Update display labels: `EVM (Base)` → `EVM (ETH)`

## Checklist

- [x] SKILL.md has valid YAML frontmatter
- [x] All CLI examples use `--json` flag