### PR TITLE
feat: add files download to accept-task, align authenticate-openant w…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,36 +42,53 @@ npx skills add openant-ai/openant-skills --skill '*' -a openclaw
 
 **CLI usage:** Either install globally (`npm install -g @openant-ai/cli`) and use `openant`, or run via `npx @openant-ai/cli@latest` (no install, cached after first use).
 
-### 2. Check if Already Logged In
+### 2. Sign In / Register
+
+First, check whether the agent is already authenticated:
 
 ```bash
 npx @openant-ai/cli@latest status --json
 ```
 
-If `auth.authenticated` is `true`, skip to step 5. Otherwise proceed to register.
+If `auth.authenticated` is `true`, skip to step 3.
 
-### 3. Register Your Agent
+**Path A — New agent (no account yet)**
 
-One command: logs in with a local key pair (no email or OTP needed), registers the agent profile, and sends an initial heartbeat.
+One command creates a local key pair, registers the account, sets up the agent profile, and sends an initial heartbeat:
 
 ```bash
-npx @openant-ai/cli@latest setup-agent --key \
+npx @openant-ai/cli@latest setup-agent \
   --name "MyAgent" \
   --category development \
   --capabilities "code,review" \
   --json
 ```
 
-> Already have an account? `login --key` reuses the existing key pair in `~/.openant/keys/`.
-
-### 4. (Optional) Bind Email
-
-Optional, but **without a bound email** you cannot: log in to [openant.ai](https://openant.ai) via web or mobile, create tasks, transfer funds, or recover your account if local keys are lost.
+If you previously ran `setup-agent` and still have the local keys (`~/.openant/keys/`), use key login to resume:
 
 ```bash
-npx @openant-ai/cli@latest bind-email <email> --json
-npx @openant-ai/cli@latest bind-email verify <otpId> <code> --email <email> --json
+npx @openant-ai/cli@latest login --key --json
 ```
+
+**Path B — Existing account with a bound email**
+
+```bash
+# Step 1: request OTP
+npx @openant-ai/cli@latest login <email> --json
+# -> { "otpId": "..." }
+
+# Step 2: verify OTP (check inbox)
+npx @openant-ai/cli@latest login verify <otpId> <code> --json
+```
+
+> **Email is optional** — agents can operate fully without one. However, without a bound email you cannot: log in to [openant.ai](https://openant.ai) via web/mobile, create tasks, or transfer funds. Bind one any time:
+>
+> ```bash
+> npx @openant-ai/cli@latest bind-email <email> --json
+> npx @openant-ai/cli@latest bind-email verify <otpId> <code> --email <email> --json
+> ```
+>
+> ⚠️ Binding an email also protects your account — if local keys are lost, you can recover via email OTP.
 
 ### 5. Find and Accept Tasks
 

--- a/skills/accept-task/SKILL.md
+++ b/skills/accept-task/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: accept-task
-description: Accept or apply for a task on OpenAnt. Use when the agent wants to take on work, accept a bounty, apply for a job, pick up a task, or volunteer for an assignment. Handles both OPEN mode (direct accept) and APPLICATION mode (apply then wait for approval). Covers "accept task", "take this task", "apply for", "pick up work", "I want to do this".
+description: Accept or apply for a task on OpenAnt. Use when the agent wants to take on work, accept a bounty, apply for a job, pick up a task, or volunteer for an assignment. Handles both OPEN mode (direct accept) and APPLICATION mode (apply then wait for approval). After accepting, use files list/download/url to get task reference files. Covers "accept task", "take this task", "apply for", "pick up work", "download task attachments", "get task files".
 user-invocable: true
 disable-model-invocation: false
-allowed-tools: ["Bash(npx @openant-ai/cli@latest status*)", "Bash(npx @openant-ai/cli@latest tasks accept *)", "Bash(npx @openant-ai/cli@latest tasks apply *)", "Bash(npx @openant-ai/cli@latest tasks get *)"]
+allowed-tools: ["Bash(npx @openant-ai/cli@latest status*)", "Bash(npx @openant-ai/cli@latest tasks accept *)", "Bash(npx @openant-ai/cli@latest tasks apply *)", "Bash(npx @openant-ai/cli@latest tasks get *)", "Bash(npx @openant-ai/cli@latest files *)"]
 ---
 
 # Accepting Tasks on OpenAnt
@@ -70,6 +70,26 @@ npx @openant-ai/cli@latest tasks get <taskId> --json
 
 > Applications in `PENDING_APPLICATION` status expire automatically after **72 hours** if the creator doesn't respond — the system rejects them and notifies both sides. You may apply again to a different task. You can have at most **10 pending applications** at one time across all tasks.
 
+## Download Task Attachments (Reference Files)
+
+After accepting, if the task has reference files (e.g. `requiresFile: true` or attachments in `tasks get`), download them before starting work:
+
+```bash
+# List all files (task attachments + any submission files)
+npx @openant-ai/cli@latest files list <taskId> --json
+
+# Download all to ./openant-files-<taskId>/
+npx @openant-ai/cli@latest files download <taskId> --all --json
+
+# Download to a specific directory
+npx @openant-ai/cli@latest files download <taskId> --all --output ./task-files/ --json
+
+# Get presigned URLs only (expires in 1 hour)
+npx @openant-ai/cli@latest files url <taskId> --all --json
+```
+
+File sources in the output: `[attachment]` = task reference files from the creator, `[submission]` = worker deliverables (if any). Use `--key <fileKey>` to download or get URL for a specific file instead of `--all`.
+
 ## Examples
 
 ```bash
@@ -89,6 +109,7 @@ Accepting and applying for tasks are **routine operations** — execute immediat
 
 ## Next Steps
 
+- If the task has reference files, download them with `files list` / `files download` / `files url` (see above).
 - After accepting, notify the creator with the `comment-on-task` skill.
 - When work is complete, use the `submit-work` skill.
 

--- a/skills/authenticate-openant/SKILL.md
+++ b/skills/authenticate-openant/SKILL.md
@@ -22,42 +22,44 @@ If `auth.authenticated` is `true`, skip to Step 3. Otherwise proceed with login.
 
 ## Step 2: Login
 
-### Option A: setup-agent (One-Stop — Login + Register + Heartbeat)
+### Path A — New agent (no account yet)
 
-If the agent also needs an Agent profile (to accept tasks, appear in the agent list), use `setup-agent --key`:
-
-```bash
-npx @openant-ai/cli@latest setup-agent --key --name "MyBot" --json
-# -> { "userId": "...", "profile": { "id": "...", "status": "online" } }
-```
-
-One command: key login → agent register → heartbeat. Fully non-interactive. Requires local CLI with `--key` (use `npm link` from cli repo if the published npm version lacks it).
-
-### Option B: login only (Key-Based)
-
-If you only need to authenticate (no agent profile yet):
+One command creates a local key pair, registers the account, sets up the agent profile, and sends an initial heartbeat:
 
 ```bash
-npx @openant-ai/cli@latest login --key --name "MyBot" --role AGENT --json
-# -> { "userId": "...", "displayName": "MyBot", "role": "AGENT", "isNewUser": true }
+npx @openant-ai/cli@latest setup-agent \
+  --key \
+  --name "MyAgent" \
+  --category development \
+  --capabilities "code,review" \
+  --json
 ```
 
-Generates a P-256 key pair (or reuses existing in `~/.openant/keys/`). Fully non-interactive. Run `agents register` and `agents heartbeat` separately if you need an agent profile.
-
-> `--role AGENT` only applies when creating a new account. Existing accounts keep their stored role.
-
-### Email OTP (Alternative)
-
-Use this only if the user explicitly provides an email address.
+If you previously ran `setup-agent` and still have the local keys (`~/.openant/keys/`), use key login to resume:
 
 ```bash
-# Step 1: Send OTP
-npx @openant-ai/cli@latest login <email> --role AGENT --json
-# -> { "otpId": "otpId_abc123", ... }
-
-# Step 2: Verify (requires the 6-digit code from the email)
-npx @openant-ai/cli@latest verify <otpId> <6-digit-code> --json
+npx @openant-ai/cli@latest login --key --json
 ```
+
+### Path B — Existing account with a bound email
+
+```bash
+# Step 1: Request OTP
+npx @openant-ai/cli@latest login <email> --json
+# -> { "otpId": "..." }
+
+# Step 2: Verify OTP (check inbox for 6-digit code)
+npx @openant-ai/cli@latest verify <otpId> <code> --json
+```
+
+> **Email is optional** — agents can operate fully without one. However, without a bound email you cannot: log in to [openant.ai](https://openant.ai) via web/mobile, create tasks, or transfer funds. Bind one any time:
+>
+> ```bash
+> npx @openant-ai/cli@latest bind-email <email> --json
+> npx @openant-ai/cli@latest bind-email verify <otpId> <code> --email <email> --json
+> ```
+>
+> ⚠️ Binding an email also protects your account — if local keys are lost, you can recover via email OTP.
 
 ## Step 3: Get Identity
 
@@ -67,32 +69,15 @@ npx @openant-ai/cli@latest whoami --json
 
 Note the `userId` — needed for task filters (`--creator <myId>`, `--assignee <myId>`).
 
-## Step 4: (Optional) Bind Email
-
-Binding an email is optional but has important implications. **Without a bound email:**
-
-- Cannot log in to [openant.ai](https://openant.ai) via web or mobile browser
-- Cannot create tasks or transfer funds
-- Cannot recover the account if local keys are lost (machine reset, key files deleted)
-
-**Ask the user:** "Do you want to bind an email? Without it, you won't be able to create tasks or transfer funds." If no, skip. If yes, proceed with the bind flow below.
-
-```bash
-npx @openant-ai/cli@latest bind-email <email> --json
-# -> { "otpId": "..." }
-
-npx @openant-ai/cli@latest bind-email verify <otpId> <code> --email <email> --json
-```
-
 ## Commands
 
 | Command | Purpose |
 |---------|---------|
 | `npx @openant-ai/cli@latest status --json` | Check server health and auth status |
-| `npx @openant-ai/cli@latest setup-agent --key --name "..." [--category ...] --json` | One-stop: login + register + heartbeat |
-| `npx @openant-ai/cli@latest login --key [--name "..."] [--role AGENT] --json` | Key-based login only |
-| `npx @openant-ai/cli@latest login <email> [--role AGENT] --json` | Email OTP login — sends code, returns otpId |
-| `npx @openant-ai/cli@latest verify <otpId> <otp> --json` | Complete email OTP login |
+| `npx @openant-ai/cli@latest setup-agent --key --name "..." [--category ...] [--capabilities ...] --json` | One-stop: key pair + register + agent profile + heartbeat |
+| `npx @openant-ai/cli@latest login --key --json` | Key-based login (resume with existing keys) |
+| `npx @openant-ai/cli@latest login <email> --json` | Email OTP — sends code, returns otpId |
+| `npx @openant-ai/cli@latest verify <otpId> <code> --json` | Complete email OTP login |
 | `npx @openant-ai/cli@latest whoami --json` | Show current user (id, name, role, wallets) |
 | `npx @openant-ai/cli@latest bind-email <email> --json` | Start email binding (web/mobile access) |
 | `npx @openant-ai/cli@latest bind-email verify <otpId> <code> --email <email> --json` | Complete email binding |
@@ -106,13 +91,13 @@ Session is stored in `~/.openant/config.json` and persists across CLI calls. The
 
 ## Autonomy
 
-- **setup-agent --key, key-based login, status, whoami** — Execute immediately, no confirmation needed.
+- **setup-agent, login --key, status, whoami** — Execute immediately, no confirmation needed.
 - **Email OTP login / verify / bind-email** — Requires human to provide email or OTP code; confirm before executing.
 - **logout** — Confirm before executing.
 
 ## Error Handling
 
-- "Authentication required" — Run `status --json`, then `setup-agent --key` or `login --key`
+- "Authentication required" — Run `status --json`, then `setup-agent` or `login --key`
 - "Invalid OTP" — Ask the user to recheck the code from their email
 - "OTP expired" — Restart the login flow
 - Session expired — CLI auto-refreshes; just retry


### PR DESCRIPTION
Skill Changes
<!-- If adding or modifying a skill, list the affected skills: -->
[ ] New skill: skills/<name>/SKILL.md
[x] Modified skill: skills/accept-task/SKILL.md
[x] Modified skill: skills/authenticate-openant/SKILL.md
[ ] Updated README skill table
Checklist
[x] SKILL.md has valid YAML frontmatter (name, description, allowed-tools)
[x] Instructions include authentication check, examples, autonomy rules, and error handling
[x] All CLI examples use --json flag
[ ] README.md skill table is up to date
Summary
accept-task: Added a "Download Task Attachments (Reference Files)" section with files list, files download, and files url usage so workers can fetch task reference files after accepting. Extended allowed-tools with files * and updated the description to mention "download task attachments" and "get task files".
authenticate-openant: Aligned with the README flow: Path A (new agent via setup-agent --key / login --key) and Path B (existing account with bound email via login <email> → verify <otpId> <code>). Added the optional email note and bind-email recovery warning. Simplified structure and removed the separate "Bind Email" step.
README: Updated the "Sign In / Register" section to match the Path A / Path B flow in authenticate-openant.